### PR TITLE
ci: bump GitHub Actions to latest majors and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # "chore" prefix so amended Dependabot commits pass the commit-msg hook.
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      gh-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,9 +12,9 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install poetry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install poetry
@@ -38,7 +38,7 @@ jobs:
         run: ~/.local/bin/poetry run mkdocs build --strict
       - name: Upload PR preview artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-pr-${{ github.event.pull_request.number }}
           path: site/
@@ -46,9 +46,12 @@ jobs:
           retention-days: 14
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
+          # v4 began excluding dotfiles by default; opt back in so mkdocs-emitted
+          # files like .nojekyll (which disables Pages' Jekyll processing) are preserved.
+          include-hidden-files: true
 
   deploy:
     needs: build
@@ -60,4 +63,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,9 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup python ${{matrix.python-version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python-version}}
       - name: Install poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
@@ -55,7 +55,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Why

Every action across the four workflows is one or more majors behind, and Dependabot wasn't watching the repo. This PR catches everything up and turns on automated tracking so future bumps surface as small, scoped PRs instead of needing a periodic sweep.

## What

Two commits, each independently reviewable:

### 1. `ci: bump GitHub Actions to latest major versions`

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `softprops/action-gh-release` | v2 | **v3** |

All but one are pure Node 20 → Node 24 runtime moves. GitHub-hosted `ubuntu-latest` runners already meet the v2.327.1+ minimum, so there's no functional change for this repo.

The one substantive change is **`upload-pages-artifact` v4 dropping dotfiles by default**. v5 added the `include-hidden-files` input precisely to opt back in. The bump in `docs.yml` includes `include-hidden-files: true` so any mkdocs-emitted dotfile (notably `.nojekyll`, which disables GitHub Pages' Jekyll processing) survives the upload — preserving the pre-bump behavior.

### 2. `ci: add Dependabot configuration for pip and github-actions`

`.github/dependabot.yml`:

- **`pip`** ecosystem (Dependabot reads `pyproject.toml` + `poetry.lock`).
- **`github-actions`** ecosystem (every action under `.github/workflows/`).
- Both run **weekly**.
- Patch + minor updates per ecosystem are **grouped into a single PR** to keep the review surface small; **major updates land individually** so each potentially-breaking bump is reviewed on its own (matches what we just did manually).
- `commit-message.prefix: "chore"` so Dependabot PRs land as `chore(deps): bump …` and pass the conventional-commit `commit-msg` pre-commit hook configured in this repo when amended locally.

## Verification

- YAML parses for all four workflow files and the new `dependabot.yml`.
- Tag/version pattern in `release.yml` unchanged; no semver tooling affected.
- No code-coverage-impacting changes; `pytest`/`ruff`/`mypy` are unaffected.

## Notes

- **Pre-release tag pattern** in `release.yml` (e.g. `1.6.0-rc1`) still excluded by design.
- **OIDC trusted publishing** still deferred — token-based publish keeps working.
- After merge, Dependabot's first run will fire on its weekly schedule; expect grouped pip + github-actions PRs to start landing then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)